### PR TITLE
Use smaller modules to reduce package size

### DIFF
--- a/lib/CacheSwap.js
+++ b/lib/CacheSwap.js
@@ -1,159 +1,107 @@
+'use strict';
+
 var fs = require('fs'),
 	path = require('path'),
 	os = require('os');
 
-var _ = require('lodash'),
-	asyncEachSeries = require('async-each-series'),
+var assign = require('object-assign'),
+  mkdirp = require('mkdirp'),
 	rimraf = require('rimraf');
 
 var CacheSwap = function (opts) {
-	this.options = _.defaults(opts || {}, {
+	this.options = assign({
 		tmpDir: os.tmpDir(),
 		cacheDirName: 'defaultCacheSwap'
-	});
+	}, opts);
 };
 
-_.extend(CacheSwap.prototype, {
+assign(CacheSwap.prototype, {
+  clear: function (category, done) {
+  	var dir = path.join(this.options.tmpDir, this.options.cacheDirName);
 
-	clear: function (category, done) {
-		var dir = path.join(this.options.tmpDir, this.options.cacheDirName);
+  	if (category) {
+  		dir = path.join(dir, category);
+  	}
 
-		if (category) {
-			dir = path.join(dir, category);
-		}
+  	// rm -rf for node
+  	rimraf(dir, done);
+  },
 
-		// rm -rf for node
-		rimraf(dir, done);
-	},
+  hasCached: function (category, hash, done) {
+  	var filePath = this.getCachedFilePath(category, hash);
 	
-	hasCached: function (category, hash, done) {
-		var filePath = this.getCachedFilePath(category, hash);
-		
-		fs.exists(filePath, function (exists) {
-			return done(exists, exists ? filePath : null);
-		});
-	},
+  	fs.exists(filePath, function (exists) {
+  		return done(exists, exists ? filePath : null);
+  	});
+  },
 
-	getCached: function (category, hash, done) {
-		this.hasCached(category, hash, function (exists, filePath) {
-			if (!exists) {
-				return done();
-			}
+  getCached: function (category, hash, done) {
+  	var filePath = this.getCachedFilePath(category, hash);
+  
+  	fs.readFile(filePath, function (err, fileStream) {
+  		if (err) {
+        if (err.code === 'ENOENT') {
+          return done();
+        }
 
-			fs.readFile(filePath, function (err, fileStream) {
-				if (err) {
-					return done(err);
-				}
+  			return done(err);
+  		}
 
-				done(null, {
-					contents: fileStream.toString(),
-					path: filePath
-				});
-			});
-		});
-	},
+  		done(null, {
+  			contents: fileStream.toString(),
+  			path: filePath
+  		});
+  	});
+  },
 
-	addCached: function (category, hash, contents, done) {
-		var filePath = this.getCachedFilePath(category, hash);
+  addCached: function (category, hash, contents, done) {
+  	var filePath = this.getCachedFilePath(category, hash);
 
-		this._prepPath(filePath, function (err) {
-			if (err) {
-				return done(err);
-			}
+  	this._prepPath(filePath, function (err) {
+  		if (err) {
+  			return done(err);
+  		}
 
-			fs.writeFile(filePath, contents, function (err) {
-				if (err) {
-					return done(err);
-				}
+  		fs.writeFile(filePath, contents, {mode: parseInt('0777', 8)}, function (err) {
+  			if (err) {
+  				return done(err);
+  			}
 
-				fs.chmod(filePath, parseInt('0777', 8), function () {
-					done(null, filePath);
-				});
-			});
-		});
-	},
+  			fs.chmod(filePath, parseInt('0777', 8), function () {
+  				done(null, filePath);
+  			});
+  		});
+  	});
+  },
 
-	removeCached: function (category, hash, done) {
-		var filePath = this.getCachedFilePath(category, hash);
+  removeCached: function (category, hash, done) {
+  	var filePath = this.getCachedFilePath(category, hash);
 
-		fs.exists(filePath, function (exists) {
-			if (!exists) {
-				done();
-			}
+  	fs.unlink(filePath, function (err) {
+  		if (err) {
+        if (err.code === 'ENOENT') {
+          return done();
+        }
+  			return done(err);
+  		}
 
-			fs.unlink(filePath, function (err) {
-				if (err) {
-					return done(err);
-				}
+  		done();
+  	});
+  },
 
-				done();
-			});
-		});
-	},
+  getCachedFilePath: function (category, hash) {
+  	return path.join(this.options.tmpDir, this.options.cacheDirName, category, hash);
+  },
 
-	getCachedFilePath: function (category, hash) {
-		return path.join(this.options.tmpDir, this.options.cacheDirName, category, hash);
-	},
+  _prepCategory: function (category, done) {
+  	var filePath = this.getCachedFilePath(category, 'prep');
 
-	_prepCategory: function (category, done) {
-		var filePath = this.getCachedFilePath(category, 'prep');
+  	this._prepPath(filePath, done);
+  },
 
-		this._prepPath(filePath, done);
-	},
-
-	_prepPath: function (filePath, done) {
-		// TODO: This probably could be optimized a bit, but really, is it worth it?
-
-		var makeDir = function (dir, cb) {
-
-			fs.exists(dir, function (exists) {
-				if (exists) {
-					// Already created, go ahead and continue
-					return cb();
-				}
-
-				// Create and continue
-				fs.mkdir(dir, parseInt('0777', 8), function (err) {
-					// No harm if the error is that the directory already exists
-					if (err && err.code !== 'EEXIST') {
-						return cb(err);
-					}
-
-					// Make double sure we set the mode, some OS's default mode
-					// does not allow writes on new directories (CentOS)
-					fs.chmod(dir, parseInt('0777', 8), function (err) {
-						if (err) {
-							return cb(err);
-						}
-
-						cb();
-					});
-				});
-			});
-		};
-
-		var tmpDir = this.options.tmpDir,
-			dirName = path.dirname(filePath),
-			partDir = path.relative(tmpDir, dirName),
-			prev = '',
-			// Get all paths we need to possibly create between temp and file dir.
-			toCreate = _.map(partDir.split(path.sep), function (part) {
-				var full = path.join(tmpDir, prev, part);
-
-				prev = path.join(prev, part);
-
-				return full;
-			});
-
-		// Create each dir
-		asyncEachSeries(toCreate, makeDir, function (err) {
-			if (err) {
-				return done(err);
-			}
-
-			done();
-		});
-	}
+  _prepPath: function (filePath, done) {
+      mkdirp(path.dirname(filePath), {mode: parseInt('0777', 8)}, done);
+  }
 });
 
 module.exports = CacheSwap;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "cache-swap",
   "version": "0.1.0",
   "description": "A simple temp file based swap for speeding up operations",
-  "main": "index.js",
   "files": [
     "index.js",
     "lib"
@@ -11,7 +10,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "node_modules/jshint/bin/jshint lib/*.js test/*.js index.js && node_modules/mocha/bin/mocha"
+    "test": "jshint lib/*.js test/*.js index.js && mocha"
   },
   "repository": "git@github.com:jgable/cache-swap.git",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
   "author": "Jacob Gable <jacob.gable@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "async-each-series": "^0.1.0",
-    "lodash": "^2.4.1",
+    "mkdirp": "^0.5.0",
+    "object-assign": "^2.0.0",
     "rimraf": "^2.2.8"
   },
   "devDependencies": {
     "jshint": "^2.5.6",
-    "mocha": "^1.21.4",
+    "mocha": "^2.1.0",
     "should": "^4.0.4"
   }
 }

--- a/test/cacheSwap_spec.js
+++ b/test/cacheSwap_spec.js
@@ -3,7 +3,7 @@ var fs = require('fs'),
 
 var should = require('should');
 
-var CacheSwap = require('../lib/cacheSwap');
+var CacheSwap = require('..');
 
 describe('cacheSwap', function () {
 	var swap,


### PR DESCRIPTION
* I replaced `lodash.defaults` with [object-assign](https://github.com/sindresorhus/object-assign) to reduce source size.
* I updated `_prepPath` method.
  * [mkdirp](https://github.com/substack/node-mkdirp) module does what `_prepPath` method did, so we don't reinvent it.
* I simplified file paths.
  * `node_modules/.bin` paths are not needed in npm scripts.
  * `main` field in package.json is not needed if the main file is `index.js`.
