### PR TITLE
Add option to use a lightweight cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,20 @@
 
 A lightweight file swap cache backed by temp files.
 
+## Constructor
+
+var swap = new CacheSwap({
+    cacheDirName: 'my-cache'
+  });
+
+## Settings
+
+The constructor accepts an optional settings object with the following settings:
+
+1. tmpDir [String] => directory where the cached directory will be saved; **Default**: Your OS's tmp directory
+2. cacheDirName [String] => name of the cached directory; **Default**: defaultCacheSwap
+3. light [Boolean] => allows you to store only the hash digest of your files as opposed to the entire contents; **Default**: false
+
 ## Example
 
 ```javascript

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ assign(CacheSwap.prototype, {
         return;
       }
 
-      if(self.options.light) {
+      if (self.options.light) {
         contents = hash;
       }
 
@@ -102,7 +102,7 @@ assign(CacheSwap.prototype, {
   },
 
   getCachedFilePath: function(category, hash, filename) {
-    if(this.options.light) {
+    if (this.options.light) {
       return path.join(this.options.tmpDir, this.options.cacheDirName, category, filename).replace(/\.\w+/, '');
     }
 

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 /* eslint-env mocha */
+/* eslint max-nested-callbacks: ["warn", 7] */
 'use strict';
 
 const path = require('path');
@@ -11,125 +12,178 @@ describe('cacheSwap', () => {
   let swap;
   const category = 'testcat';
   const hash = '1234';
+  const filename = 'testfile';
 
-  beforeEach(done => {
-    swap = new CacheSwap();
-    swap.clear(category, done);
-  });
+  describe('default settings', () => {
+    beforeEach(done => {
+      swap = new CacheSwap();
+      swap.clear(category, done);
+    });
 
-  it('getCachedFilePath', () => {
-    let expect = path.join(swap.options.tmpDir, swap.options.cacheDirName, category, hash);
-    swap.getCachedFilePath(category, hash).should.equal(expect);
-  });
+    it('getCachedFilePath', () => {
+      let expect = path.join(swap.options.tmpDir, swap.options.cacheDirName, category, hash);
+      swap.getCachedFilePath(category, hash).should.equal(expect);
+    });
 
-  it('addCached', done => {
-    swap.addCached(category, hash, 'foo', (err, filePath) => {
-      if (err) {
-        done(err);
-        return;
-      }
-
-      fs.stat(filePath, (statErr, stats) => {
-        if (statErr) {
-          done(statErr);
+    it('addCached', done => {
+      swap.addCached(category, hash, 'foo', filename, (err, filePath) => {
+        if (err) {
+          done(err);
           return;
         }
 
-        const mode = '0' + (stats.mode & parseInt('777', 8)).toString(8);
-        mode.should.equal(process.platform === 'win32' ? '0666' : '0777');
-
-        fs.readFile(filePath, (readErr, tmpContents) => {
-          if (readErr) {
-            done(readErr);
+        fs.stat(filePath, (statErr, stats) => {
+          if (statErr) {
+            done(statErr);
             return;
           }
 
-          String(tmpContents).should.equal('foo');
+          const mode = '0' + (stats.mode & parseInt('777', 8)).toString(8);
+          mode.should.equal(process.platform === 'win32' ? '0666' : '0777');
+
+          fs.readFile(filePath, (readErr, tmpContents) => {
+            if (readErr) {
+              done(readErr);
+              return;
+            }
+
+            String(tmpContents).should.equal('foo');
+            done();
+          });
+        });
+      });
+    });
+
+    it('getCached (does exist)', done => {
+      swap.addCached(category, hash, 'bar', filename, (addErr, filePath) => {
+        if (addErr) {
+          done(addErr);
+          return;
+        }
+
+        swap.getCached(category, hash, filename, (getErr, details) => {
+          if (getErr) {
+            done(getErr);
+            return;
+          }
+
+          should.exist(details);
+          details.contents.should.equal('bar');
+          details.path.should.equal(filePath);
           done();
+        });
+      });
+    });
+
+    it('hasCached (doesn\'t exist)', done => {
+      swap.hasCached(category, hash, filename, (exists, filePath) => {
+        exists.should.equal(false);
+        should.not.exist(filePath);
+
+        done();
+      });
+    });
+
+    it('hasCached (does exist)', done => {
+      swap.addCached(category, hash, 'baz', filename, (err, filePath) => {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        swap.hasCached(category, hash, filename, (exists, existsFilePath) => {
+          exists.should.equal(true);
+          existsFilePath.should.equal(filePath);
+
+          done();
+        });
+      });
+    });
+
+    it('removeCached', done => {
+      swap.addCached(category, hash, 'qux', filename, (err, filePath) => {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        swap.hasCached(category, hash, filename, (exists, existsFilePath) => {
+          exists.should.equal(true);
+          existsFilePath.should.equal(filePath);
+
+          swap.removeCached(category, hash, filename, removeErr => {
+            if (removeErr) {
+              done(removeErr);
+              return;
+            }
+
+            swap.hasCached(category, hash, filename, result => {
+              result.should.equal(false);
+              done();
+            });
+          });
         });
       });
     });
   });
 
-  it('getCached (doesn\'t exist)', done => {
-    swap.getCached(category, hash, (err, details) => {
-      if (err) {
-        done(err);
-        return;
-      }
-
-      should.not.exist(details);
-      done();
+  describe('light version', () => {
+    beforeEach(done => {
+      swap = new CacheSwap({light: true});
+      swap.clear(category, done);
     });
-  });
 
-  it('getCached (does exist)', done => {
-    swap.addCached(category, hash, 'bar', (addErr, filePath) => {
-      if (addErr) {
-        done(addErr);
-        return;
-      }
+    it('getCachedFilePath (light version)', () => {
+      let expect = path.join(swap.options.tmpDir, swap.options.cacheDirName, category, filename);
+      swap.getCachedFilePath(category, hash, filename).should.equal(expect);
+    });
 
-      swap.getCached(category, hash, (getErr, details) => {
-        if (getErr) {
-          done(getErr);
+    it('addCached (light-version)', done => {
+      swap.addCached(category, hash, 'foo', filename, (err, filePath) => {
+        if (err) {
+          done(err);
           return;
         }
 
-        should.exist(details);
-        details.contents.should.equal('bar');
-        details.path.should.equal(filePath);
-        done();
-      });
-    });
-  });
-
-  it('hasCached (doesn\'t exist)', done => {
-    swap.hasCached(category, hash, (exists, filePath) => {
-      exists.should.equal(false);
-      should.not.exist(filePath);
-
-      done();
-    });
-  });
-
-  it('hasCached (does exist)', done => {
-    swap.addCached(category, hash, 'baz', (err, filePath) => {
-      if (err) {
-        done(err);
-        return;
-      }
-
-      swap.hasCached(category, hash, (exists, existsFilePath) => {
-        exists.should.equal(true);
-        existsFilePath.should.equal(filePath);
-
-        done();
-      });
-    });
-  });
-
-  it('removeCached', done => {
-    swap.addCached(category, hash, 'qux', (err, filePath) => {
-      if (err) {
-        done(err);
-        return;
-      }
-
-      swap.hasCached(category, hash, (exists, existsFilePath) => {
-        exists.should.equal(true);
-        existsFilePath.should.equal(filePath);
-
-        swap.removeCached(category, hash, removeErr => {
-          if (removeErr) {
-            done(removeErr);
+        fs.stat(filePath, (statErr, stats) => {
+          if (statErr) {
+            done(statErr);
             return;
           }
 
-          swap.hasCached(category, hash, result => {
-            result.should.equal(false);
+          const mode = '0' + (stats.mode & parseInt('777', 8)).toString(8);
+          mode.should.equal(process.platform === 'win32' ? '0666' : '0777');
+
+          fs.readFile(filePath, (readErr, tmpContents) => {
+            if (readErr) {
+              done(readErr);
+              return;
+            }
+
+            String(tmpContents).should.equal(hash);
             done();
           });
+        });
+      });
+    });
+
+    it('getCached (does exist; light-version)', done => {
+      swap.addCached(category, hash, 'bar', filename, (addErr, filePath) => {
+        if (addErr) {
+          done(addErr);
+          return;
+        }
+
+        swap.getCached(category, hash, filename, (getErr, details) => {
+          if (getErr) {
+            done(getErr);
+            return;
+          }
+
+          should.exist(details);
+          details.contents.should.equal(hash);
+          details.path.should.equal(filePath);
+          done();
         });
       });
     });


### PR DESCRIPTION
The background for this PR is that the cache can be become very bloated if the contents of all files are cached in full. Ours amounted to 560MB in production. So this one - together with a few tweaks in gulp-cache - is meant to allow us to cache the digest only. 
