### PR TITLE
Replace deprecated tmpDir by tmpdir

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var assign = require('object-assign');
 var fs = require('graceful-fs');
 var mkdirp = require('mkdirp');
 var rimraf = require('rimraf');
-var tmpDir = require('os').tmpDir();
+var tmpDir = require('os').tmpdir();
 
 function CacheSwap(options) {
   this.options = assign({


### PR DESCRIPTION
`tmpDir()` is deprecated in Node.js 7 : https://github.com/nodejs/node/pull/6739